### PR TITLE
Automatic claim sponsoring

### DIFF
--- a/agglayer/grpc/agglayer_grpc_client.go
+++ b/agglayer/grpc/agglayer_grpc_client.go
@@ -10,7 +10,7 @@ import (
 	v1 "buf.build/gen/go/agglayer/agglayer/protocolbuffers/go/agglayer/node/v1"
 	v1types "buf.build/gen/go/agglayer/interop/protocolbuffers/go/agglayer/interop/types/v1"
 	"github.com/agglayer/aggkit/agglayer/types"
-	"github.com/agglayer/aggkit/bridgesync"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	aggkitgrpc "github.com/agglayer/aggkit/grpc"
 	treetypes "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -286,7 +286,7 @@ func convertToProtoImportedBridgeExit(ibe *types.ImportedBridgeExit) (*v1types.I
 	importedBridgeExit := &v1types.ImportedBridgeExit{
 		BridgeExit: convertToProtoBridgeExit(ibe.BridgeExit),
 		GlobalIndex: &v1types.FixedBytes32{
-			Value: common.BigToHash(bridgesync.GenerateGlobalIndex(
+			Value: common.BigToHash(aggkitcommon.GenerateGlobalIndex(
 				ibe.GlobalIndex.MainnetFlag,
 				ibe.GlobalIndex.RollupIndex,
 				ibe.GlobalIndex.LeafIndex)).Bytes(),

--- a/agglayer/types/types.go
+++ b/agglayer/types/types.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/agglayer/aggkit/bridgesync"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -453,7 +452,7 @@ func (g *GlobalIndex) String() string {
 func (g *GlobalIndex) Hash() common.Hash {
 	return crypto.Keccak256Hash(
 		aggkitcommon.BigIntToLittleEndianBytes(
-			bridgesync.GenerateGlobalIndex(g.MainnetFlag, g.RollupIndex, g.LeafIndex),
+			aggkitcommon.GenerateGlobalIndex(g.MainnetFlag, g.RollupIndex, g.LeafIndex),
 		),
 	)
 }
@@ -928,7 +927,7 @@ func (c *ImportedBridgeExit) Hash() common.Hash {
 // GlobalIndexToLittleEndianBytes converts the global index to a byte slice in little-endian format
 func (c *ImportedBridgeExit) GlobalIndexToLittleEndianBytes() []byte {
 	return aggkitcommon.BigIntToLittleEndianBytes(
-		bridgesync.GenerateGlobalIndex(
+		aggkitcommon.GenerateGlobalIndex(
 			c.GlobalIndex.MainnetFlag,
 			c.GlobalIndex.RollupIndex,
 			c.GlobalIndex.LeafIndex,

--- a/agglayer/types/types_test.go
+++ b/agglayer/types/types_test.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/agglayer/aggkit/bridgesync"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/tree/types"
@@ -1229,7 +1228,7 @@ func TestCertificate_FEPHashToSign(t *testing.T) {
 			expectedHash: crypto.Keccak256Hash(
 				common.HexToHash("0xdef456").Bytes(),
 				crypto.Keccak256(aggkitcommon.BigIntToLittleEndianBytes(
-					bridgesync.GenerateGlobalIndex(true, 0, 1),
+					aggkitcommon.GenerateGlobalIndex(true, 0, 1),
 				), bridgeExit.Hash().Bytes()),
 				aggkitcommon.Uint64ToLittleEndianBytes(100),
 				common.HexToHash("0x123abc").Bytes(),

--- a/aggsender/aggchainproofclient/aggchain_proof_client.go
+++ b/aggsender/aggchainproofclient/aggchain_proof_client.go
@@ -8,7 +8,7 @@ import (
 	aggkitProverV1Grpc "buf.build/gen/go/agglayer/provers/grpc/go/aggkit/prover/v1/proverv1grpc"
 	aggkitProverV1Proto "buf.build/gen/go/agglayer/provers/protocolbuffers/go/aggkit/prover/v1"
 	"github.com/agglayer/aggkit/aggsender/types"
-	"github.com/agglayer/aggkit/bridgesync"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	aggkitgrpc "github.com/agglayer/aggkit/grpc"
 	treetypes "github.com/agglayer/aggkit/tree/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -168,7 +168,7 @@ func convertAggchainProofRequestToGrpcRequest(
 		convertedImportedBridgeExitsWithBlockNumber[i] = &aggkitProverV1Proto.ImportedBridgeExitWithBlockNumber{
 			BlockNumber: importedBridgeExitWithBlockNumber.BlockNumber,
 			GlobalIndex: &agglayerInteropTypesV1Proto.FixedBytes32{
-				Value: common.BigToHash(bridgesync.GenerateGlobalIndex(
+				Value: common.BigToHash(aggkitcommon.GenerateGlobalIndex(
 					importedBridgeExitWithBlockNumber.ImportedBridgeExit.GlobalIndex.MainnetFlag,
 					importedBridgeExitWithBlockNumber.ImportedBridgeExit.GlobalIndex.RollupIndex,
 					importedBridgeExitWithBlockNumber.ImportedBridgeExit.GlobalIndex.LeafIndex,

--- a/aggsender/flows/flow_base.go
+++ b/aggsender/flows/flow_base.go
@@ -280,7 +280,7 @@ func (f *baseFlow) ConvertClaimToImportedBridgeExit(claim bridgesync.Claim) (*ag
 		Metadata:           metaData,
 	}
 
-	mainnetFlag, rollupIndex, leafIndex, err := bridgesync.DecodeGlobalIndex(claim.GlobalIndex)
+	mainnetFlag, rollupIndex, leafIndex, err := aggkitcommon.DecodeGlobalIndex(claim.GlobalIndex)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding global index: %w", err)
 	}

--- a/aggsender/flows/flow_pp_test.go
+++ b/aggsender/flows/flow_pp_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/agglayer/aggkit/aggsender/mocks"
 	"github.com/agglayer/aggkit/aggsender/types"
 	"github.com/agglayer/aggkit/bridgesync"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/log"
 	treetypes "github.com/agglayer/aggkit/tree/types"
@@ -244,7 +245,7 @@ func TestGetImportedBridgeExits(t *testing.T) {
 					DestinationAddress:  common.HexToAddress("0x4567"),
 					Amount:              big.NewInt(111),
 					Metadata:            []byte("metadata1"),
-					GlobalIndex:         bridgesync.GenerateGlobalIndex(false, 1, 1),
+					GlobalIndex:         aggkitcommon.GenerateGlobalIndex(false, 1, 1),
 					GlobalExitRoot:      common.HexToHash("0x7891"),
 					RollupExitRoot:      common.HexToHash("0xaaab"),
 					MainnetExitRoot:     common.HexToHash("0xbbba"),
@@ -333,7 +334,7 @@ func TestGetImportedBridgeExits(t *testing.T) {
 					DestinationAddress:  common.HexToAddress("0xabc"),
 					Amount:              big.NewInt(200),
 					Metadata:            []byte("data"),
-					GlobalIndex:         bridgesync.GenerateGlobalIndex(true, 0, 2),
+					GlobalIndex:         aggkitcommon.GenerateGlobalIndex(true, 0, 2),
 					GlobalExitRoot:      common.HexToHash("0x7891"),
 					RollupExitRoot:      common.HexToHash("0xbbb"),
 					MainnetExitRoot:     common.HexToHash("0xccc"),

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -84,8 +84,8 @@ type BridgeService struct {
 	readTimeout   time.Duration
 	writeTimeout  time.Duration
 	networkID     uint32
-	sponsorL1     ClaimSponsorer
-	sponsorL2     ClaimSponsorer
+	sponsorFwd    ClaimSponsorer
+	sponsorRev    ClaimSponsorer
 	l1InfoTree    L1InfoTreer
 	injectedGERs  LastGERer
 	bridgeL1      Bridger
@@ -137,8 +137,8 @@ func New(
 		readTimeout:   cfg.ReadTimeout,
 		writeTimeout:  cfg.WriteTimeout,
 		networkID:     cfg.NetworkID,
-		sponsorL1:     sponsorRev,
-		sponsorL2:     sponsorFwd,
+		sponsorFwd:    sponsorFwd,
+		sponsorRev:    sponsorRev,
 		l1InfoTree:    l1InfoTree,
 		injectedGERs:  injectedGERs,
 		bridgeL1:      bridgeL1,
@@ -147,6 +147,7 @@ func New(
 		router:        router,
 	}
 
+	log.Infof("Bridge service created with network ID: %d", cfg.NetworkID)
 	b.registerRoutes()
 	cfg.Logger.Info("bridge service initialized successfully")
 
@@ -998,9 +999,9 @@ func (b *BridgeService) SponsorClaimHandler(c *gin.Context) {
 	}
 	cnt.Add(ctx, 1)
 
-	sponsor := b.sponsorL1
-	if claim.OriginNetwork == 1 {
-		sponsor = b.sponsorL2
+	sponsor := b.sponsorFwd
+	if claim.DestinationNetwork == mainnetNetworkID {
+		sponsor = b.sponsorRev
 	}
 
 	if sponsor == nil {
@@ -1052,9 +1053,9 @@ func (b *BridgeService) GetSponsoredClaimStatusHandler(c *gin.Context) {
 	}
 	cnt.Add(ctx, 1)
 
-	sponsor := b.sponsorL1
+	sponsor := b.sponsorFwd
 	if networkID == mainnetNetworkID {
-		sponsor = b.sponsorL2
+		sponsor = b.sponsorRev
 	}
 	if sponsor == nil {
 		b.logger.Warn("claim sponsoring not supported by this client")
@@ -1378,12 +1379,11 @@ func (b *BridgeService) createSandboxMetadata() *types.SandboxMetadata {
 	}
 
 	// Build list of supported L2 networks
-	primaryL2ChainID := uint32(b.sandboxConfig.L2Node.ChainID)
-	supportedL2Networks := []uint32{primaryL2ChainID}
+	supportedL2Networks := []uint32{}
 
 	// Add other valid L2 network IDs that the bridge service supports
 	for networkID := uint32(1); networkID <= 3; networkID++ {
-		if networkID != primaryL2ChainID && b.isValidL2NetworkID(networkID) {
+		if b.isValidL2NetworkID(networkID) {
 			supportedL2Networks = append(supportedL2Networks, networkID)
 		}
 	}

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -464,9 +464,9 @@ func (b *BridgeService) GetClaimsHandler(c *gin.Context) {
 	// Get pending claims from all bridge databases where destination_network matches
 	// We need to check both L1 and L2 bridge databases for pending claims targeting this network
 	// Use network ID directly as requested
-	
+
 	b.logger.Debugf("Looking for pending claims targeting network ID %d", networkID)
-	
+
 	var allPendingBridges []*bridgesync.Bridge
 	var totalPendingCount int
 
@@ -497,15 +497,15 @@ func (b *BridgeService) GetClaimsHandler(c *gin.Context) {
 
 	// Combine completed and pending claims
 	var claimResponses []*types.ClaimResponse
-	
+
 	// Add completed claims
 	completedResponses := aggkitcommon.MapSlice(completedClaims, NewClaimResponse)
 	claimResponses = append(claimResponses, completedResponses...)
-	
+
 	// Add pending claims
 	pendingResponses := aggkitcommon.MapSlice(pendingBridges, NewPendingClaimResponse)
 	claimResponses = append(claimResponses, pendingResponses...)
-	
+
 	totalCount := completedCount + pendingCount
 
 	result := types.ClaimsResult{
@@ -1001,13 +1001,13 @@ func (b *BridgeService) SponsorClaimHandler(c *gin.Context) {
 		return
 	}
 
-	if claim.DestinationNetwork != b.networkID {
-		b.logger.Warnf("invalid destination network %d (expected %d)", claim.DestinationNetwork, b.networkID)
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": fmt.Sprintf("this client only sponsors claims for destination network %d", b.networkID),
-		})
-		return
-	}
+	// if claim.DestinationNetwork != b.networkID {
+	// 	b.logger.Warnf("invalid destination network %d (expected %d)", claim.DestinationNetwork, b.networkID)
+	// 	c.JSON(http.StatusBadRequest, gin.H{
+	// 		"error": fmt.Sprintf("this client only sponsors claims for destination network %d", b.networkID),
+	// 	})
+	// 	return
+	// }
 
 	if err := b.sponsor.AddClaimToQueue(&claim); err != nil {
 		b.logger.Errorf("failed to add claim to queue: %v", err)
@@ -1258,7 +1258,7 @@ func (b *BridgeService) getFirstL1InfoTreeIndexForL2Bridge(ctx context.Context, 
 	// (produced by the smart contract call verifyBatches / verifyBatchesTrustedAggregator)
 	// are included in the L1 info tree. As per the current implementation (smart contracts) of the protocol
 	// this is true. This could change in the future
-	
+
 	// In sandbox mode, if verified batches are not available, return a default L1 info tree index
 	if b.isSandboxMode() {
 		_, err := b.l1InfoTree.GetLastVerifiedBatches(b.networkID)
@@ -1272,7 +1272,7 @@ func (b *BridgeService) getFirstL1InfoTreeIndexForL2Bridge(ctx context.Context, 
 		}
 		// If verified batches exist in sandbox mode, continue with normal processing
 	}
-	
+
 	lastVerified, err := b.l1InfoTree.GetLastVerifiedBatches(b.networkID)
 	if err != nil {
 		return 0, err
@@ -1368,14 +1368,14 @@ func (b *BridgeService) createSandboxMetadata() *types.SandboxMetadata {
 	// Build list of supported L2 networks
 	primaryL2ChainID := uint32(b.sandboxConfig.L2Node.ChainID)
 	supportedL2Networks := []uint32{primaryL2ChainID}
-	
+
 	// Add other valid L2 network IDs that the bridge service supports
 	for networkID := uint32(1); networkID <= 3; networkID++ {
 		if networkID != primaryL2ChainID && b.isValidL2NetworkID(networkID) {
 			supportedL2Networks = append(supportedL2Networks, networkID)
 		}
 	}
-	
+
 	return &types.SandboxMetadata{
 		SandboxMode:      true,
 		AutoSettle:       b.sandboxConfig.AutoSettle,
@@ -1384,11 +1384,11 @@ func (b *BridgeService) createSandboxMetadata() *types.SandboxMetadata {
 		SettlementDelay:  b.sandboxConfig.SettlementDelay.String(),
 		GeneratedAt:      time.Now().Unix(),
 		DevMetadata: map[string]interface{}{
-			"bridge_mode": "sandbox",
-			"l1_chain_id": b.sandboxConfig.L1Node.ChainID,
-			"l2_chain_id": b.sandboxConfig.L2Node.ChainID, // Primary L2
-			"supported_l2_networks": supportedL2Networks, // All supported L2s
-			"multi_l2_enabled": len(supportedL2Networks) > 1,
+			"bridge_mode":           "sandbox",
+			"l1_chain_id":           b.sandboxConfig.L1Node.ChainID,
+			"l2_chain_id":           b.sandboxConfig.L2Node.ChainID, // Primary L2
+			"supported_l2_networks": supportedL2Networks,            // All supported L2s
+			"multi_l2_enabled":      len(supportedL2Networks) > 1,
 		},
 	}
 }
@@ -1438,8 +1438,6 @@ func (b *BridgeService) enhanceClaimProofWithSandbox(claimProof *types.ClaimProo
 func (b *BridgeService) isClaimInstantlyReady() bool {
 	return b.isSandboxMode() && b.sandboxConfig.InstantClaims
 }
-
-
 
 // isValidL2NetworkID validates if a network ID is a valid L2 network ID
 // For multi-L2 scenarios, this allows network IDs 1-3 for L2 chains, and 31337-31339 for local development

--- a/bridgeservice/bridge.go
+++ b/bridgeservice/bridge.go
@@ -84,7 +84,8 @@ type BridgeService struct {
 	readTimeout   time.Duration
 	writeTimeout  time.Duration
 	networkID     uint32
-	sponsor       ClaimSponsorer
+	sponsorL1     ClaimSponsorer
+	sponsorL2     ClaimSponsorer
 	l1InfoTree    L1InfoTreer
 	injectedGERs  LastGERer
 	bridgeL1      Bridger
@@ -97,7 +98,8 @@ type BridgeService struct {
 // New returns instance of BridgeService
 func New(
 	cfg *Config,
-	sponsor ClaimSponsorer,
+	sponsorFwd ClaimSponsorer,
+	sponsorRev ClaimSponsorer,
 	l1InfoTree L1InfoTreer,
 	injectedGERs LastGERer,
 	bridgeL1 Bridger,
@@ -135,7 +137,8 @@ func New(
 		readTimeout:   cfg.ReadTimeout,
 		writeTimeout:  cfg.WriteTimeout,
 		networkID:     cfg.NetworkID,
-		sponsor:       sponsor,
+		sponsorL1:     sponsorRev,
+		sponsorL2:     sponsorFwd,
 		l1InfoTree:    l1InfoTree,
 		injectedGERs:  injectedGERs,
 		bridgeL1:      bridgeL1,
@@ -995,21 +998,18 @@ func (b *BridgeService) SponsorClaimHandler(c *gin.Context) {
 	}
 	cnt.Add(ctx, 1)
 
-	if b.sponsor == nil {
+	sponsor := b.sponsorL1
+	if claim.OriginNetwork == 1 {
+		sponsor = b.sponsorL2
+	}
+
+	if sponsor == nil {
 		b.logger.Warn("claim sponsoring not supported by this client")
 		c.JSON(http.StatusBadRequest, gin.H{"error": "this client does not support claim sponsoring"})
 		return
 	}
 
-	// if claim.DestinationNetwork != b.networkID {
-	// 	b.logger.Warnf("invalid destination network %d (expected %d)", claim.DestinationNetwork, b.networkID)
-	// 	c.JSON(http.StatusBadRequest, gin.H{
-	// 		"error": fmt.Sprintf("this client only sponsors claims for destination network %d", b.networkID),
-	// 	})
-	// 	return
-	// }
-
-	if err := b.sponsor.AddClaimToQueue(&claim); err != nil {
+	if err := sponsor.AddClaimToQueue(&claim); err != nil {
 		b.logger.Errorf("failed to add claim to queue: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to add claim to queue: " + err.Error()})
 		return
@@ -1026,6 +1026,7 @@ func (b *BridgeService) SponsorClaimHandler(c *gin.Context) {
 // Only available if claim sponsoring is enabled.
 // @Tags claim-sponsoring
 // @Param global_index query string true "Global index of the claim (big.Int format)"
+// @Param network_id query uint32 true "Origin network ID"
 // @Produce json
 // @Success 200 {object} string "Claim sponsorship status"
 // @Failure 400 {object} types.ErrorResponse "Bad Request"
@@ -1034,7 +1035,14 @@ func (b *BridgeService) SponsorClaimHandler(c *gin.Context) {
 func (b *BridgeService) GetSponsoredClaimStatusHandler(c *gin.Context) {
 	globalIndexRaw := c.Query(globalIndexParam)
 
-	b.logger.Debugf("GetSponsoredClaimStatus request received (claim global index=%s)", globalIndexRaw)
+	networkID, err := parseUintQuery(c, networkIDParam, true, uint32(0))
+	if err != nil {
+		b.logger.Warnf(errNetworkID, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	b.logger.Debugf("GetSponsoredClaimStatus request received (claim global index=%s, origin network=%d)", globalIndexRaw, networkID)
 	ctx, cancel := context.WithTimeout(c, b.readTimeout)
 	defer cancel()
 
@@ -1044,7 +1052,11 @@ func (b *BridgeService) GetSponsoredClaimStatusHandler(c *gin.Context) {
 	}
 	cnt.Add(ctx, 1)
 
-	if b.sponsor == nil {
+	sponsor := b.sponsorL1
+	if networkID == mainnetNetworkID {
+		sponsor = b.sponsorL2
+	}
+	if sponsor == nil {
 		b.logger.Warn("claim sponsoring not supported by this client")
 		c.JSON(http.StatusBadRequest, gin.H{"error": "this client does not support claim sponsoring"})
 		return
@@ -1057,7 +1069,7 @@ func (b *BridgeService) GetSponsoredClaimStatusHandler(c *gin.Context) {
 	}
 
 	globalIndex, _ := new(big.Int).SetString(globalIndexRaw, 0)
-	claim, err := b.sponsor.GetClaim(globalIndex)
+	claim, err := sponsor.GetClaim(globalIndex)
 	if err != nil {
 		b.logger.Errorf("failed to get claim status for global index %d: %v", globalIndex, err)
 		c.JSON(http.StatusInternalServerError,

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -64,7 +64,7 @@ func newBridgeWithMocks(t *testing.T, networkID uint32) bridgeWithMocks {
 		WriteTimeout: 0,
 		NetworkID:    networkID,
 	}
-	b.bridge = New(cfg, b.sponsor, b.l1InfoTree, b.injectedGERs, b.bridgeL1, b.bridgeL2)
+	b.bridge = New(cfg, b.sponsor, b.sponsor, b.l1InfoTree, b.injectedGERs, b.bridgeL1, b.bridgeL2)
 	return b
 }
 
@@ -641,13 +641,13 @@ func TestGetClaimsHandler(t *testing.T) {
 		bridgeMocks.bridgeL1.EXPECT().
 			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything).
 			Return(expectedClaims, len(expectedClaims), nil)
-		
+
 		// Mock pending claims from L1 bridge database (empty for this test)
 		// mainnetNetworkID (0) maps to chain ID 1
 		bridgeMocks.bridgeL1.EXPECT().
 			GetPendingClaimsPaged(mock.Anything, page, pageSize, []uint32{1}, mock.Anything).
 			Return([]*bridgesync.Bridge{}, 0, nil)
-		
+
 		// Mock pending claims from L2 bridge database (empty for this test)
 		bridgeMocks.bridgeL2.EXPECT().
 			GetPendingClaimsPaged(mock.Anything, page, pageSize, []uint32{1}, mock.Anything).
@@ -693,14 +693,14 @@ func TestGetClaimsHandler(t *testing.T) {
 		bridgeMocks.bridgeL2.EXPECT().
 			GetClaimsPaged(mock.Anything, page, pageSize, mock.Anything, mock.Anything).
 			Return(expectedClaims, len(expectedClaims), nil)
-		
+
 		// Mock pending claims from L1 bridge database (empty for this test)
 		// Network ID 10 maps to chain ID 1101 (in default mapping)
 		bridgeMocks.bridgeL1.EXPECT().
 			GetPendingClaimsPaged(mock.Anything, page, pageSize, []uint32{10}, mock.Anything).
 			Return([]*bridgesync.Bridge{}, 0, nil)
-		
-		// Mock pending claims from L2 bridge database (empty for this test) 
+
+		// Mock pending claims from L2 bridge database (empty for this test)
 		bridgeMocks.bridgeL2.EXPECT().
 			GetPendingClaimsPaged(mock.Anything, page, pageSize, []uint32{10}, mock.Anything).
 			Return([]*bridgesync.Bridge{}, 0, nil)
@@ -739,7 +739,7 @@ func TestGetClaimsHandler(t *testing.T) {
 			Return(nil, 0, errors.New(fooErrMsg))
 
 		query := url.Values{}
-		query.Set(networkIDParam, "0")  // Use L1 mainnet network ID
+		query.Set(networkIDParam, "0") // Use L1 mainnet network ID
 		query.Set(pageNumberParam, "1")
 		query.Set(pageSizeParam, "10")
 
@@ -1707,10 +1707,11 @@ func TestGetLastReorgEventHandler(t *testing.T) {
 func TestGetSponsoredClaimStatusHandler(t *testing.T) {
 	t.Run("Client does not support sponsored claims", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
-		bridgeMocks.bridge.sponsor = nil
+		bridgeMocks.bridge.sponsorL2 = nil
 
 		queryParams := url.Values{
 			globalIndexParam: []string{"1"},
+			networkIDParam:   []string{"0"},
 		}
 
 		response := performRequest(t, bridgeMocks.bridge.router, http.MethodGet, fmt.Sprintf("%s/sponsored-claim-status?%s", BridgeV1Prefix, queryParams.Encode()), nil)
@@ -1735,6 +1736,7 @@ func TestGetSponsoredClaimStatusHandler(t *testing.T) {
 
 		queryParams := url.Values{
 			globalIndexParam: []string{"1"},
+			networkIDParam:   []string{"0"},
 		}
 
 		response := performRequest(t, bridgeMocks.bridge.router, http.MethodGet, fmt.Sprintf("%s/sponsored-claim-status?%s", BridgeV1Prefix, queryParams.Encode()), nil)
@@ -1754,6 +1756,7 @@ func TestGetSponsoredClaimStatusHandler(t *testing.T) {
 
 		queryParams := url.Values{
 			globalIndexParam: []string{"1"},
+			networkIDParam:   []string{"0"},
 		}
 
 		response := performRequest(t, bridgeMocks.bridge.router, http.MethodGet, fmt.Sprintf("%s/sponsored-claim-status?%s", BridgeV1Prefix, queryParams.Encode()), nil)
@@ -1769,7 +1772,7 @@ func TestGetSponsoredClaimStatusHandler(t *testing.T) {
 func TestSponsorClaimHandler(t *testing.T) {
 	t.Run("Client does not support sponsored claims", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
-		bridgeMocks.bridge.sponsor = nil
+		bridgeMocks.bridge.sponsorL2 = nil
 
 		claim := claimsponsor.Claim{
 			GlobalIndex:        common.Big1,

--- a/bridgeservice/bridge_test.go
+++ b/bridgeservice/bridge_test.go
@@ -1707,7 +1707,7 @@ func TestGetLastReorgEventHandler(t *testing.T) {
 func TestGetSponsoredClaimStatusHandler(t *testing.T) {
 	t.Run("Client does not support sponsored claims", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
-		bridgeMocks.bridge.sponsorL2 = nil
+		bridgeMocks.bridge.sponsorFwd = nil
 
 		queryParams := url.Values{
 			globalIndexParam: []string{"1"},
@@ -1772,7 +1772,7 @@ func TestGetSponsoredClaimStatusHandler(t *testing.T) {
 func TestSponsorClaimHandler(t *testing.T) {
 	t.Run("Client does not support sponsored claims", func(t *testing.T) {
 		bridgeMocks := newBridgeWithMocks(t, l2NetworkID)
-		bridgeMocks.bridge.sponsorL2 = nil
+		bridgeMocks.bridge.sponsorFwd = nil
 
 		claim := claimsponsor.Claim{
 			GlobalIndex:        common.Big1,

--- a/bridgeservice/utils.go
+++ b/bridgeservice/utils.go
@@ -7,6 +7,7 @@ import (
 
 	bridgetypes "github.com/agglayer/aggkit/bridgeservice/types"
 	"github.com/agglayer/aggkit/bridgesync"
+	"github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/gin-gonic/gin"
 )
@@ -171,7 +172,7 @@ func NewPendingClaimResponse(bridge *bridgesync.Bridge) *bridgetypes.ClaimRespon
 	if mainnetFlag {
 		rollupIndex = 0
 	}
-	globalIndex := bridgesync.GenerateGlobalIndex(mainnetFlag, rollupIndex, bridge.DepositCount)
+	globalIndex := common.GenerateGlobalIndex(mainnetFlag, rollupIndex, bridge.DepositCount)
 
 	return &bridgetypes.ClaimResponse{
 		GlobalIndex:        bridgetypes.BigIntString(globalIndex.String()),

--- a/bridgeservice/utils.go
+++ b/bridgeservice/utils.go
@@ -92,25 +92,6 @@ func parseUint32SliceParam(c *gin.Context, key string) ([]uint32, error) {
 	return result, nil
 }
 
-// chainIDToNetworkID converts chain ID back to network ID for API responses
-// This ensures consistent network ID usage in API responses regardless of what's stored in database
-func chainIDToNetworkID(chainID uint32) uint32 {
-	switch chainID {
-	case 1:
-		return 0 // Ethereum mainnet
-	case 1101:
-		return 1 // Polygon zkEVM L2
-	case 137:
-		return 2 // Polygon
-	case 8453:
-		return 3 // Base
-	default:
-		// For unknown chain IDs or if it's already a network ID, return as-is
-		// This handles cases where the database already contains network IDs
-		return chainID
-	}
-}
-
 // NewBridgeResponse creates a new BridgeResponse instance out of the provided Bridge instance
 func NewBridgeResponse(bridge *bridgesync.Bridge) *bridgetypes.BridgeResponse {
 	return &bridgetypes.BridgeResponse{
@@ -142,7 +123,7 @@ func NewClaimResponse(claim *bridgesync.Claim) *bridgetypes.ClaimResponse {
 
 	return &bridgetypes.ClaimResponse{
 		GlobalIndex:        bridgetypes.BigIntString(claim.GlobalIndex.String()),
-		DestinationNetwork: chainIDToNetworkID(claim.DestinationNetwork),
+		DestinationNetwork: claim.DestinationNetwork,
 		TxHash:             bridgetypes.Hash(claim.TxHash.Hex()),
 		Amount:             bridgetypes.BigIntString(claim.Amount.String()),
 		BlockNum:           claim.BlockNum,

--- a/bridgesync/bridgecalldata_test.go
+++ b/bridgesync/bridgecalldata_test.go
@@ -118,7 +118,7 @@ func TestBridgeCallData(t *testing.T) {
 	go reorgDetector.Start(ctx) //nolint:errcheck
 
 	bridgeSync, err := NewL1(ctx, dbPathBridgeSyncL1, bridgeProxyAddr, 1, aggkittypes.LatestBlock, reorgDetector, ethClient,
-		initialBlock, waitForNewBlocksPeriod, retryPeriod, retriesCount, originNetwork, false, false)
+		initialBlock, waitForNewBlocksPeriod, retryPeriod, retriesCount, originNetwork, false, false, nil)
 	require.NoError(t, err)
 	go bridgeSync.Start(ctx)
 

--- a/bridgesync/bridgecalldata_test.go
+++ b/bridgesync/bridgecalldata_test.go
@@ -118,7 +118,7 @@ func TestBridgeCallData(t *testing.T) {
 	go reorgDetector.Start(ctx) //nolint:errcheck
 
 	bridgeSync, err := NewL1(ctx, dbPathBridgeSyncL1, bridgeProxyAddr, 1, aggkittypes.LatestBlock, reorgDetector, ethClient,
-		initialBlock, waitForNewBlocksPeriod, retryPeriod, retriesCount, originNetwork, false, false, nil)
+		initialBlock, waitForNewBlocksPeriod, retryPeriod, retriesCount, originNetwork, false, false, nil, 0)
 	require.NoError(t, err)
 	go bridgeSync.Start(ctx)
 

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -80,6 +80,7 @@ func NewL1(
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
 	autosponsor ClaimEnqueuer,
+	networkID uint32,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -98,6 +99,7 @@ func NewL1(
 		syncFullClaims,
 		requireStorageContentCompatibility,
 		autosponsor,
+		networkID,
 	)
 }
 
@@ -118,6 +120,7 @@ func NewL2(
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
 	autosponsor ClaimEnqueuer,
+	networkID uint32,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -136,6 +139,7 @@ func NewL2(
 		syncFullClaims,
 		requireStorageContentCompatibility,
 		autosponsor,
+		networkID,
 	)
 }
 
@@ -156,6 +160,7 @@ func newBridgeSync(
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
 	autosponsor ClaimEnqueuer,
+	networkID uint32,
 ) (*BridgeSync, error) {
 	logger := log.WithFields("module", syncerID.String())
 
@@ -170,7 +175,7 @@ func newBridgeSync(
 			bridge.String(), err)
 		return nil, err
 	}
-	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, autosponsor, originNetwork)
+	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, autosponsor, networkID)
 	if err != nil {
 		return nil, err
 	}

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -79,6 +79,7 @@ func NewL1(
 	originNetwork uint32,
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
+	autosponsor ClaimEnqueuer,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -96,7 +97,7 @@ func NewL1(
 		originNetwork,
 		syncFullClaims,
 		requireStorageContentCompatibility,
-		nil,
+		autosponsor,
 	)
 }
 

--- a/bridgesync/bridgesync.go
+++ b/bridgesync/bridgesync.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/pp/l2-sovereign-chain/polygonzkevmbridgev2"
+	"github.com/agglayer/aggkit/claimsponsor"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/reorgdetector"
 	"github.com/agglayer/aggkit/sync"
@@ -43,6 +44,10 @@ var (
 type ReorgDetector interface {
 	sync.ReorgDetector
 	GetLastReorgEvent(ctx context.Context) (reorgdetector.ReorgEvent, error)
+}
+
+type ClaimEnqueuer interface {
+	AddClaimToQueue(c *claimsponsor.Claim) error
 }
 
 // BridgeSync manages the state of the exit tree for the bridge contract by processing Ethereum blockchain events.
@@ -91,6 +96,7 @@ func NewL1(
 		originNetwork,
 		syncFullClaims,
 		requireStorageContentCompatibility,
+		nil,
 	)
 }
 
@@ -110,6 +116,7 @@ func NewL2(
 	originNetwork uint32,
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
+	autosponsor ClaimEnqueuer,
 ) (*BridgeSync, error) {
 	return newBridgeSync(
 		ctx,
@@ -127,6 +134,7 @@ func NewL2(
 		originNetwork,
 		syncFullClaims,
 		requireStorageContentCompatibility,
+		autosponsor,
 	)
 }
 
@@ -146,6 +154,7 @@ func newBridgeSync(
 	originNetwork uint32,
 	syncFullClaims bool,
 	requireStorageContentCompatibility bool,
+	autosponsor ClaimEnqueuer,
 ) (*BridgeSync, error) {
 	logger := log.WithFields("module", syncerID.String())
 
@@ -160,7 +169,7 @@ func newBridgeSync(
 			bridge.String(), err)
 		return nil, err
 	}
-	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger)
+	processor, err := newProcessor(dbPath, "bridge_sync_"+syncerID.String(), logger, autosponsor, originNetwork)
 	if err != nil {
 		return nil, err
 	}

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -69,6 +69,7 @@ func TestNewLx(t *testing.T) {
 		false,
 		true,
 		nil,
+		0,
 	)
 
 	require.NoError(t, err)
@@ -92,6 +93,7 @@ func TestNewLx(t *testing.T) {
 		false,
 		true,
 		nil,
+		0,
 	)
 
 	require.NoError(t, err)
@@ -119,6 +121,7 @@ func TestNewLx(t *testing.T) {
 		false,
 		true,
 		nil,
+		0,
 	)
 	t.Log(err)
 	require.Error(t, err)
@@ -228,6 +231,7 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 		false,
 		false,
 		nil,
+		0,
 	)
 	require.NoError(t, err)
 
@@ -361,6 +365,7 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 		false,
 		false,
 		nil,
+		0,
 	)
 	require.NoError(t, err)
 

--- a/bridgesync/bridgesync_test.go
+++ b/bridgesync/bridgesync_test.go
@@ -68,6 +68,7 @@ func TestNewLx(t *testing.T) {
 		originNetwork,
 		false,
 		true,
+		nil,
 	)
 
 	require.NoError(t, err)
@@ -90,6 +91,7 @@ func TestNewLx(t *testing.T) {
 		originNetwork,
 		false,
 		true,
+		nil,
 	)
 
 	require.NoError(t, err)
@@ -116,6 +118,7 @@ func TestNewLx(t *testing.T) {
 		originNetwork,
 		false,
 		true,
+		nil,
 	)
 	t.Log(err)
 	require.Error(t, err)
@@ -224,6 +227,7 @@ func TestBridgeSync_GetTokenMappings(t *testing.T) {
 		originNetwork,
 		false,
 		false,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -356,6 +360,7 @@ func TestBridgeSync_GetLegacyTokenMigrations(t *testing.T) {
 		originNetwork,
 		false,
 		false,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -826,12 +826,15 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 				p.log.Errorf("failed to insert bridge event at block %d: %v", block.Num, err)
 				return err
 			}
-			if p.enqueuer != nil && event.Bridge.DestinationNetwork == p.networkId {
+			log.Infof("Bridge event has been inserted: bridge destination network %d and networkID %d", event.Bridge.DestinationNetwork, p.networkId)
+			if p.enqueuer != nil {
+				log.Infof("I entered the if for the adding the claim to the claimsponsor queue")
 				claim := bridgeToClaim(event.Bridge)
 				if err := p.enqueuer.AddClaimToQueue(claim); err != nil {
 					p.log.Errorf("auto-sponsor enqueue failed: %v", err)
 				}
 			}
+			log.Infof("Finished adding the claim to the claimsponsor queue")
 		}
 
 		if event.Claim != nil {

--- a/bridgesync/processor.go
+++ b/bridgesync/processor.go
@@ -13,6 +13,7 @@ import (
 
 	bridgetypes "github.com/agglayer/aggkit/bridgeservice/types"
 	"github.com/agglayer/aggkit/bridgesync/migrations"
+	"github.com/agglayer/aggkit/claimsponsor"
 	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/db/compatibility"
@@ -29,9 +30,6 @@ import (
 )
 
 const (
-	globalIndexPartSize = 4
-	globalIndexMaxSize  = 9
-
 	// bridgeTableName is the name of the table that stores bridge events
 	bridgeTableName = "bridge"
 
@@ -283,9 +281,11 @@ type processor struct {
 	halted       bool
 	haltedReason string
 	compatibility.CompatibilityDataStorager[sync.RuntimeData]
+	enqueuer  ClaimEnqueuer
+	networkId uint32
 }
 
-func newProcessor(dbPath string, name string, logger *log.Logger) (*processor, error) {
+func newProcessor(dbPath string, name string, logger *log.Logger, enqueuer ClaimEnqueuer, networkId uint32) (*processor, error) {
 	err := migrations.RunMigrations(dbPath)
 	if err != nil {
 		return nil, err
@@ -304,6 +304,8 @@ func newProcessor(dbPath string, name string, logger *log.Logger) (*processor, e
 			db.NewKeyValueStorage(database),
 			name,
 		),
+		enqueuer:  enqueuer,
+		networkId: networkId,
 	}, nil
 }
 
@@ -496,7 +498,7 @@ func (p *processor) GetPendingClaimsPaged(
 	// Build WHERE clause to find bridges that haven't been claimed
 	// We need to find bridges where the global index doesn't exist in the claims table
 	whereClause := p.buildPendingClaimsFilterClause(networkIDs, fromAddress)
-	
+
 	// For pending claims, we need bridges that don't have corresponding claims
 	// Use a LEFT JOIN to find bridges without claims
 	// NOTE: This simplified global index calculation must match the GenerateGlobalIndex function
@@ -536,7 +538,7 @@ func (p *processor) GetPendingClaimsPaged(
 
 	// Get the actual pending bridges
 	orderByClause := "b.block_num DESC, b.block_pos DESC"
-	
+
 	bridgeQuery := fmt.Sprintf(`
 		SELECT b.* 
 		FROM %s b
@@ -578,7 +580,7 @@ func (p *processor) GetPendingClaimsPaged(
 func (p *processor) buildPendingClaimsFilterClause(networkIDs []uint32, fromAddress string) string {
 	const clauseCapacity = 2
 	clauses := make([]string, 0, clauseCapacity)
-	
+
 	if len(networkIDs) > 0 {
 		clauses = append(clauses, buildNetworkIDsFilter(networkIDs, "b.destination_network"))
 	}
@@ -824,6 +826,12 @@ func (p *processor) ProcessBlock(ctx context.Context, block sync.Block) error {
 				p.log.Errorf("failed to insert bridge event at block %d: %v", block.Num, err)
 				return err
 			}
+			if p.enqueuer != nil && event.Bridge.DestinationNetwork == p.networkId {
+				claim := bridgeToClaim(event.Bridge)
+				if err := p.enqueuer.AddClaimToQueue(claim); err != nil {
+					p.log.Errorf("auto-sponsor enqueue failed: %v", err)
+				}
+			}
 		}
 
 		if event.Claim != nil {
@@ -951,58 +959,6 @@ func buildNetworkIDsFilter(networkIDs []uint32, networkIDColumn string) string {
 	return fmt.Sprintf("%s IN (%s)", networkIDColumn, strings.Join(placeholders, ", "))
 }
 
-func GenerateGlobalIndex(mainnetFlag bool, rollupIndex uint32, localExitRootIndex uint32) *big.Int {
-	var (
-		globalIndexBytes []byte
-		buf              [globalIndexPartSize]byte
-	)
-	if mainnetFlag {
-		globalIndexBytes = append(globalIndexBytes, big.NewInt(1).Bytes()...)
-		ri := new(big.Int).FillBytes(buf[:])
-		globalIndexBytes = append(globalIndexBytes, ri...)
-	} else {
-		ri := new(big.Int).SetUint64(uint64(rollupIndex)).FillBytes(buf[:])
-		globalIndexBytes = append(globalIndexBytes, ri...)
-	}
-	leri := new(big.Int).SetUint64(uint64(localExitRootIndex)).FillBytes(buf[:])
-	globalIndexBytes = append(globalIndexBytes, leri...)
-
-	result := new(big.Int).SetBytes(globalIndexBytes)
-
-	return result
-}
-
-// Decodes global index to its three parts:
-// 1. mainnetFlag - first byte
-// 2. rollupIndex - next 4 bytes
-// 3. localExitRootIndex - last 4 bytes
-// NOTE - mainnet flag is not in the global index bytes if it is false
-// NOTE - rollup index is 0 if mainnet flag is true
-// NOTE - rollup index is not in the global index bytes if mainnet flag is false and rollup index is 0
-func DecodeGlobalIndex(globalIndex *big.Int) (mainnetFlag bool,
-	rollupIndex uint32, localExitRootIndex uint32, err error) {
-	globalIndexBytes := globalIndex.Bytes()
-	l := len(globalIndexBytes)
-
-	if l == 0 {
-		// false, 0, 0
-		return
-	}
-
-	if l == globalIndexMaxSize {
-		// true, rollupIndex, localExitRootIndex
-		mainnetFlag = true
-	}
-
-	localExitRootFromIdx := max(l-globalIndexPartSize, 0)
-	rollupIndexFromIdx := max(localExitRootFromIdx-globalIndexPartSize, 0)
-
-	rollupIndex = aggkitcommon.BytesToUint32(globalIndexBytes[rollupIndexFromIdx:localExitRootFromIdx])
-	localExitRootIndex = aggkitcommon.BytesToUint32(globalIndexBytes[localExitRootFromIdx:])
-
-	return
-}
-
 //nolint:unparam
 func (p *processor) startTransaction(ctx context.Context, isReadOnly bool) (*sql.Tx, error) {
 	tx, err := p.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: isReadOnly})
@@ -1034,4 +990,18 @@ func (p *processor) isHalted() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.halted
+}
+
+func bridgeToClaim(b *Bridge) *claimsponsor.Claim {
+	return &claimsponsor.Claim{
+		LeafType:           b.LeafType,
+		GlobalIndex:        aggkitcommon.GenerateGlobalIndex(b.OriginNetwork == 0, b.OriginNetwork, b.DepositCount),
+		OriginNetwork:      b.OriginNetwork,
+		OriginTokenAddress: b.OriginAddress,
+		DestinationNetwork: b.DestinationNetwork,
+		DestinationAddress: b.DestinationAddress,
+		Amount:             b.Amount,
+		Metadata:           b.Metadata,
+		Status:             claimsponsor.PendingClaimStatus,
+	}
 }

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/0xPolygon/cdk-contracts-tooling/contracts/fep/etrog/polygonzkevmbridge"
 	bridgetypes "github.com/agglayer/aggkit/bridgeservice/types"
 	"github.com/agglayer/aggkit/bridgesync/migrations"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/db"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/sync"
@@ -27,7 +28,7 @@ import (
 )
 
 func TestBigIntString(t *testing.T) {
-	globalIndex := GenerateGlobalIndex(true, 0, 1093)
+	globalIndex := aggkitcommon.GenerateGlobalIndex(true, 0, 1093)
 	fmt.Println(globalIndex.String())
 
 	_, ok := new(big.Int).SetString(globalIndex.String(), 10)
@@ -47,7 +48,7 @@ func TestBigIntString(t *testing.T) {
 	claim := &Claim{
 		BlockNum:            1,
 		BlockPos:            0,
-		GlobalIndex:         GenerateGlobalIndex(true, 0, 1093),
+		GlobalIndex:         aggkitcommon.GenerateGlobalIndex(true, 0, 1093),
 		OriginNetwork:       11,
 		Amount:              big.NewInt(11),
 		OriginAddress:       common.HexToAddress("0x11"),
@@ -734,7 +735,7 @@ func TestDecodeGlobalIndex(t *testing.T) {
 	}{
 		{
 			name:                "Mainnet flag true, rollup index 0",
-			globalIndex:         GenerateGlobalIndex(true, 0, 2),
+			globalIndex:         aggkitcommon.GenerateGlobalIndex(true, 0, 2),
 			expectedMainnetFlag: true,
 			expectedRollupIndex: 0,
 			expectedLocalIndex:  2,
@@ -742,7 +743,7 @@ func TestDecodeGlobalIndex(t *testing.T) {
 		},
 		{
 			name:                "Mainnet flag true, indexes 0",
-			globalIndex:         GenerateGlobalIndex(true, 0, 0),
+			globalIndex:         aggkitcommon.GenerateGlobalIndex(true, 0, 0),
 			expectedMainnetFlag: true,
 			expectedRollupIndex: 0,
 			expectedLocalIndex:  0,
@@ -750,7 +751,7 @@ func TestDecodeGlobalIndex(t *testing.T) {
 		},
 		{
 			name:                "Mainnet flag false, rollup index 0",
-			globalIndex:         GenerateGlobalIndex(false, 0, 2),
+			globalIndex:         aggkitcommon.GenerateGlobalIndex(false, 0, 2),
 			expectedMainnetFlag: false,
 			expectedRollupIndex: 0,
 			expectedLocalIndex:  2,
@@ -758,7 +759,7 @@ func TestDecodeGlobalIndex(t *testing.T) {
 		},
 		{
 			name:                "Mainnet flag false, rollup index non-zero",
-			globalIndex:         GenerateGlobalIndex(false, 11, 0),
+			globalIndex:         aggkitcommon.GenerateGlobalIndex(false, 11, 0),
 			expectedMainnetFlag: false,
 			expectedRollupIndex: 11,
 			expectedLocalIndex:  0,
@@ -766,7 +767,7 @@ func TestDecodeGlobalIndex(t *testing.T) {
 		},
 		{
 			name:                "Mainnet flag false, indexes 0",
-			globalIndex:         GenerateGlobalIndex(false, 0, 0),
+			globalIndex:         aggkitcommon.GenerateGlobalIndex(false, 0, 0),
 			expectedMainnetFlag: false,
 			expectedRollupIndex: 0,
 			expectedLocalIndex:  0,
@@ -774,7 +775,7 @@ func TestDecodeGlobalIndex(t *testing.T) {
 		},
 		{
 			name:                "Mainnet flag false, indexes non zero",
-			globalIndex:         GenerateGlobalIndex(false, 1231, 111234),
+			globalIndex:         aggkitcommon.GenerateGlobalIndex(false, 1231, 111234),
 			expectedMainnetFlag: false,
 			expectedRollupIndex: 1231,
 			expectedLocalIndex:  111234,
@@ -788,7 +789,7 @@ func TestDecodeGlobalIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mainnetFlag, rollupIndex, localExitRootIndex, err := DecodeGlobalIndex(tt.globalIndex)
+			mainnetFlag, rollupIndex, localExitRootIndex, err := aggkitcommon.DecodeGlobalIndex(tt.globalIndex)
 			if tt.expectedErr != nil {
 				require.EqualError(t, err, tt.expectedErr.Error())
 			} else {
@@ -817,7 +818,7 @@ func TestInsertAndGetClaim(t *testing.T) {
 	testClaim := &Claim{
 		BlockNum:            1,
 		BlockPos:            0,
-		GlobalIndex:         GenerateGlobalIndex(true, 0, 1093),
+		GlobalIndex:         aggkitcommon.GenerateGlobalIndex(true, 0, 1093),
 		OriginNetwork:       11,
 		OriginAddress:       common.HexToAddress("0x11"),
 		DestinationAddress:  common.HexToAddress("0x11"),

--- a/bridgesync/processor_test.go
+++ b/bridgesync/processor_test.go
@@ -85,7 +85,7 @@ func TestBigIntString(t *testing.T) {
 func TestProcessor(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgeSyncerProcessor.db")
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, nil, 0)
 	require.NoError(t, err)
 	actions := []processAction{
 		// processed: ~
@@ -808,7 +808,7 @@ func TestInsertAndGetClaim(t *testing.T) {
 	err := migrations.RunMigrations(path)
 	require.NoError(t, err)
 	logger := log.WithFields("bridge-syncer", "foo")
-	p, err := newProcessor(path, "foo", logger)
+	p, err := newProcessor(path, "foo", logger, nil, 0)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -893,7 +893,7 @@ func TestGetBridgesPublished(t *testing.T) {
 			path := path.Join(t.TempDir(), fmt.Sprintf("bridgesyncTestGetBridgesPublished_%s.sqlite", tc.name))
 			require.NoError(t, migrations.RunMigrations(path))
 			logger := log.WithFields("bridge-syncer", "foo")
-			p, err := newProcessor(path, "foo", logger)
+			p, err := newProcessor(path, "foo", logger, nil, 0)
 			require.NoError(t, err)
 
 			tx, err := p.db.BeginTx(context.Background(), nil)
@@ -926,7 +926,7 @@ func TestGetBridgesPublished(t *testing.T) {
 func TestProcessBlockInvalidIndex(t *testing.T) {
 	path := path.Join(t.TempDir(), "aggsenderTestProcessor.sqlite")
 	logger := log.WithFields("bridge-syncer", "foo")
-	p, err := newProcessor(path, "foo", logger)
+	p, err := newProcessor(path, "foo", logger, nil, 0)
 	require.NoError(t, err)
 	err = p.ProcessBlock(context.Background(), sync.Block{
 		Num: 0,
@@ -957,7 +957,7 @@ func TestGetBridgesPaged(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgesyncGetBridgesPaged.sqlite")
 	require.NoError(t, migrations.RunMigrations(path))
 	logger := log.WithFields("bridge-syncer", "foo")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, nil, 0)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -1196,7 +1196,7 @@ func TestGetClaimsPaged(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgesyncGetClaimsPaged.sqlite")
 	require.NoError(t, migrations.RunMigrations(path))
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, nil, 0)
 	require.NoError(t, err)
 
 	tx, err := p.db.BeginTx(context.Background(), nil)
@@ -1324,7 +1324,7 @@ func TestProcessor_GetTokenMappings(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, nil, 0)
 	require.NoError(t, err)
 
 	allTokenMappings := make([]*TokenMapping, 0, tokenMappingsCount)
@@ -1423,7 +1423,7 @@ func TestProcessor_GetLegacyTokenMigrations(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, nil, 0)
 	require.NoError(t, err)
 
 	const (
@@ -1970,7 +1970,7 @@ func TestDecodeEtrogCalldata(t *testing.T) {
 func TestQueryBlockRangeOrdering(t *testing.T) {
 	path := path.Join(t.TempDir(), "bridgeSyncerProcessorOrdering.db")
 	logger := log.WithFields("module", "bridge-syncer")
-	p, err := newProcessor(path, "bridge-syncer", logger)
+	p, err := newProcessor(path, "bridge-syncer", logger, nil, 0)
 	require.NoError(t, err)
 
 	// Create test data with events in different blocks and positions

--- a/claimsponsor/claimsponsor.go
+++ b/claimsponsor/claimsponsor.go
@@ -115,7 +115,7 @@ func (c *Claim) Key() []byte {
 }
 
 type ClaimSender interface {
-	checkClaim(ctx context.Context, claim *Claim) error
+	checkClaim(ctx context.Context, claim *Claim) (*Claim, error)
 	sendClaim(ctx context.Context, claim *Claim) (string, error)
 	claimStatus(ctx context.Context, id string) (ClaimStatus, error)
 }
@@ -197,6 +197,10 @@ func (c *ClaimSponsor) claim(ctx context.Context) error {
 				return nil
 			}
 			return fmt.Errorf("error calling getClaim with globalIndex %s: %w", claim.GlobalIndex.String(), err)
+		}
+		claim, err = c.sender.checkClaim(ctx, claim)
+		if err != nil {
+			return fmt.Errorf("error checking claim: %w", err)
 		}
 		txID, err := c.sender.sendClaim(ctx, claim)
 		if err != nil {

--- a/claimsponsor/e2e_test.go
+++ b/claimsponsor/e2e_test.go
@@ -35,6 +35,7 @@ func TestE2EL1toEVML2(t *testing.T) {
 		0,
 		setup.EthTxManagerMock,
 		0, 0, time.Millisecond*10, time.Millisecond*10,
+		nil,
 	)
 	require.NoError(t, err)
 	go claimer.Start(ctx)

--- a/claimsponsor/e2e_test.go
+++ b/claimsponsor/e2e_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agglayer/aggkit/bridgesync"
 	"github.com/agglayer/aggkit/claimsponsor"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/log"
 	"github.com/agglayer/aggkit/test/helpers"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -60,7 +60,7 @@ func TestE2EL1toEVML2(t *testing.T) {
 		require.NoError(t, err)
 
 		// Request to sponsor claim
-		globalIndex := bridgesync.GenerateGlobalIndex(true, 0, i)
+		globalIndex := aggkitcommon.GenerateGlobalIndex(true, 0, i)
 		err = claimer.AddClaimToQueue(&claimsponsor.Claim{
 			LeafType:           claimsponsor.LeafTypeAsset,
 			GlobalIndex:        globalIndex,

--- a/claimsponsor/evmclaimsponsor.go
+++ b/claimsponsor/evmclaimsponsor.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/0xPolygon/zkevm-ethtx-manager/ethtxmanager"
 	ethtxtypes "github.com/0xPolygon/zkevm-ethtx-manager/types"
+	aggkitcommon "github.com/agglayer/aggkit/common"
 	configTypes "github.com/agglayer/aggkit/config/types"
+	"github.com/agglayer/aggkit/l1infotreesync"
 	"github.com/agglayer/aggkit/log"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -63,6 +65,7 @@ type EVMClaimSponsor struct {
 	sender       common.Address
 	gasOffest    uint64
 	maxGas       uint64
+	l1InfoTree   *l1infotreesync.L1InfoTreeSync
 }
 
 type EVMClaimSponsorConfig struct {
@@ -104,6 +107,7 @@ func NewEVMClaimSponsor(
 	maxRetryAttemptsAfterError int,
 	waitTxToBeMinedPeriod time.Duration,
 	waitOnEmptyQueue time.Duration,
+	l1InfoTree *l1infotreesync.L1InfoTreeSync,
 ) (*ClaimSponsor, error) {
 	abi, err := getPolygonZkEVMBridgeV2ABI()
 	if err != nil {
@@ -118,6 +122,7 @@ func NewEVMClaimSponsor(
 		gasOffest:    gasOffset,
 		maxGas:       maxGas,
 		ethTxManager: ethTxManager,
+		l1InfoTree:   l1InfoTree,
 	}
 
 	baseSponsor, err := newClaimSponsor(
@@ -136,10 +141,25 @@ func NewEVMClaimSponsor(
 	return baseSponsor, nil
 }
 
-func (c *EVMClaimSponsor) checkClaim(ctx context.Context, claim *Claim) error {
+func (c *EVMClaimSponsor) checkClaim(ctx context.Context, claim *Claim) (*Claim, error) {
+	if claimRootsEmpty(claim) {
+		_, _, l1InfoIndex, err := aggkitcommon.DecodeGlobalIndex(claim.GlobalIndex)
+		if err != nil {
+			return claim, fmt.Errorf("error decoding global_index %d: %w", claim.GlobalIndex, err)
+		}
+
+		// Set actual roots in the claim. When the claim was created these fields were left empty
+		roots, err := GetRoots(ctx, c.l1InfoTree, l1InfoIndex)
+		if err != nil {
+			return claim, fmt.Errorf("error getting root: %w", err)
+		}
+		claim.MainnetExitRoot = roots.MainnetExitRoot
+		claim.RollupExitRoot = roots.RollupExitRoot
+	}
+
 	data, err := c.buildClaimTxData(claim)
 	if err != nil {
-		return err
+		return claim, err
 	}
 
 	gas, err := c.l2Client.EstimateGas(ctx, ethereum.CallMsg{
@@ -148,14 +168,14 @@ func (c *EVMClaimSponsor) checkClaim(ctx context.Context, claim *Claim) error {
 		Data: data,
 	})
 	if err != nil {
-		return err
+		return claim, err
 	}
 
 	if gas > c.maxGas {
-		return fmt.Errorf(gasTooHighErrTemplate, gas, c.maxGas)
+		return claim, fmt.Errorf(gasTooHighErrTemplate, gas, c.maxGas)
 	}
 
-	return nil
+	return claim, nil
 }
 
 func (c *EVMClaimSponsor) sendClaim(ctx context.Context, claim *Claim) (string, error) {
@@ -193,8 +213,6 @@ func (c *EVMClaimSponsor) claimStatus(ctx context.Context, id string) (ClaimStat
 		return "", fmt.Errorf("unexpected tx status: %v", res.Status)
 	}
 }
-
-
 
 func (c *EVMClaimSponsor) buildClaimTxData(claim *Claim) ([]byte, error) {
 	// Use network IDs directly as requested
@@ -245,4 +263,8 @@ var bridgeABIJSON []byte
 
 func getPolygonZkEVMBridgeV2ABI() (abi.ABI, error) {
 	return abi.JSON(bytes.NewReader(bridgeABIJSON))
+}
+
+func claimRootsEmpty(claim *Claim) bool {
+	return claim.MainnetExitRoot == common.Hash{} && claim.RollupExitRoot == common.Hash{}
 }

--- a/claimsponsor/evmclaimsponsor.go
+++ b/claimsponsor/evmclaimsponsor.go
@@ -144,6 +144,7 @@ func NewEVMClaimSponsor(
 }
 
 func (c *EVMClaimSponsor) checkClaim(ctx context.Context, claim *Claim) (*Claim, error) {
+	// Check for MainnetExitRoot and RollupExitRoot
 	if claimRootsEmpty(claim) {
 		_, _, l1InfoIndex, err := aggkitcommon.DecodeGlobalIndex(claim.GlobalIndex)
 		if err != nil {
@@ -157,6 +158,11 @@ func (c *EVMClaimSponsor) checkClaim(ctx context.Context, claim *Claim) (*Claim,
 		}
 		claim.MainnetExitRoot = roots.MainnetExitRoot
 		claim.RollupExitRoot = roots.RollupExitRoot
+	}
+
+	// TODO: Remove this patch once the inconsistencies between networkID and chainID are solved
+	if claim.DestinationNetwork == 0 {
+		claim.DestinationNetwork = 1
 	}
 
 	data, err := c.buildClaimTxData(claim)

--- a/claimsponsor/evmclaimsponsor.go
+++ b/claimsponsor/evmclaimsponsor.go
@@ -93,6 +93,8 @@ type EVMClaimSponsorConfig struct {
 	EthTxManager ethtxmanager.Config `mapstructure:"EthTxManager"`
 	// GasOffset is the gas to add on top of the estimated gas when sending the claim txs
 	GasOffset uint64 `mapstructure:"GasOffset"`
+	// ClaimAll indicates whether to automatically sponsor all claims
+	ClaimAll bool `mapstructure:"ClaimAll"`
 }
 
 func NewEVMClaimSponsor(

--- a/claimsponsor/root_resolver.go
+++ b/claimsponsor/root_resolver.go
@@ -1,0 +1,32 @@
+package claimsponsor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agglayer/aggkit/l1infotreesync"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type Result struct {
+	MainnetExitRoot common.Hash
+	RollupExitRoot  common.Hash
+}
+
+// GetClaimProof reproduces the logic that existed in BridgeService.
+func GetRoots(
+	ctx context.Context,
+	L1InfoTree *l1infotreesync.L1InfoTreeSync,
+	l1InfoIndex uint32,
+) (*Result, error) {
+
+	leaf, err := L1InfoTree.GetInfoByIndex(ctx, l1InfoIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get L1 info tree leaf for index %d: %v", l1InfoIndex, err)
+	}
+
+	return &Result{
+		MainnetExitRoot: leaf.MainnetExitRoot,
+		RollupExitRoot:  leaf.RollupExitRoot,
+	}, nil
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -94,14 +94,19 @@ func start(cliCtx *cli.Context) error {
 
 	l1InfoTreeSync := runL1InfoTreeSyncerIfNeeded(cliCtx.Context, components, *cfg, l1Client, reorgDetectorL1)
 	claimSponsor := runClaimSponsorIfNeeded(cliCtx.Context, components, l2Client, cfg.ClaimSponsor, l1InfoTreeSync)
-	autosponsor := claimSponsor
-	if !cfg.ClaimSponsor.ClaimAll {
-		autosponsor = nil
+	var autosponsor bridgesync.ClaimEnqueuer
+	if cfg.ClaimSponsor.ClaimAll {
+		autosponsor = claimSponsor
+	}
+	if autosponsor == nil {
+		log.Infof("autosponsor not wired")
+	} else {
+		log.Infof("Autosponsor wired")
 	}
 	l1BridgeSync := runBridgeSyncL1IfNeeded(cliCtx.Context, components, cfg.BridgeL1Sync, reorgDetectorL1,
-		l1Client, 0, autosponsor)
+		l1Client, 0, autosponsor, cfg.Common.NetworkID)
 	l2BridgeSync := runBridgeSyncL2IfNeeded(cliCtx.Context, components, cfg.BridgeL2Sync, reorgDetectorL2,
-		l2Client, rollupDataQuerier.RollupID, autosponsor)
+		l2Client, rollupDataQuerier.RollupID, autosponsor, cfg.Common.NetworkID)
 	lastGERSync := runLastGERSyncIfNeeded(
 		cliCtx.Context, components, cfg.LastGERSync, reorgDetectorL2, l2Client, l1InfoTreeSync,
 	)
@@ -642,7 +647,8 @@ func runBridgeSyncL1IfNeeded(
 	reorgDetectorL1 *reorgdetector.ReorgDetector,
 	l1Client aggkittypes.EthClienter,
 	rollupID uint32,
-	autosponsor *claimsponsor.ClaimSponsor,
+	autosponsor bridgesync.ClaimEnqueuer,
+	networkID uint32,
 ) *bridgesync.BridgeSync {
 	if !isNeeded([]string{aggkitcommon.BRIDGE}, components) {
 		return nil
@@ -664,6 +670,7 @@ func runBridgeSyncL1IfNeeded(
 		true,
 		cfg.RequireStorageContentCompatibility,
 		autosponsor,
+		networkID,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL1: %s", err)
@@ -680,7 +687,8 @@ func runBridgeSyncL2IfNeeded(
 	reorgDetectorL2 *reorgdetector.ReorgDetector,
 	l2Client aggkittypes.EthClienter,
 	rollupID uint32,
-	autosponsor *claimsponsor.ClaimSponsor,
+	autosponsor bridgesync.ClaimEnqueuer,
+	networkID uint32,
 ) *bridgesync.BridgeSync {
 	if !isNeeded([]string{
 		aggkitcommon.BRIDGE,
@@ -705,6 +713,7 @@ func runBridgeSyncL2IfNeeded(
 		true,
 		cfg.RequireStorageContentCompatibility,
 		autosponsor,
+		networkID,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL2: %s", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -93,20 +93,18 @@ func start(cliCtx *cli.Context) error {
 	}
 
 	l1InfoTreeSync := runL1InfoTreeSyncerIfNeeded(cliCtx.Context, components, *cfg, l1Client, reorgDetectorL1)
-	claimSponsor := runClaimSponsorIfNeeded(cliCtx.Context, components, l2Client, cfg.ClaimSponsor, l1InfoTreeSync)
-	var autosponsor bridgesync.ClaimEnqueuer
+	claimSponsorFwd := runClaimSponsorIfNeeded(cliCtx.Context, components, l2Client, cfg.ClaimSponsor, l1InfoTreeSync)
+	claimSponsorRev := runClaimSponsorIfNeeded(cliCtx.Context, components, l1Client, cfg.ClaimSponsorReverse, l1InfoTreeSync)
+	var autosponsorL1, autosponsorL2 bridgesync.ClaimEnqueuer
 	if cfg.ClaimSponsor.ClaimAll {
-		autosponsor = claimSponsor
+		autosponsorL1 = claimSponsorRev
+		autosponsorL2 = claimSponsorFwd
 	}
-	if autosponsor == nil {
-		log.Infof("autosponsor not wired")
-	} else {
-		log.Infof("Autosponsor wired")
-	}
+
 	l1BridgeSync := runBridgeSyncL1IfNeeded(cliCtx.Context, components, cfg.BridgeL1Sync, reorgDetectorL1,
-		l1Client, 0, autosponsor, cfg.Common.NetworkID)
+		l1Client, 0, autosponsorL1, 0)
 	l2BridgeSync := runBridgeSyncL2IfNeeded(cliCtx.Context, components, cfg.BridgeL2Sync, reorgDetectorL2,
-		l2Client, rollupDataQuerier.RollupID, autosponsor, cfg.Common.NetworkID)
+		l2Client, rollupDataQuerier.RollupID, autosponsorL2, cfg.Common.NetworkID)
 	lastGERSync := runLastGERSyncIfNeeded(
 		cliCtx.Context, components, cfg.LastGERSync, reorgDetectorL2, l2Client, l1InfoTreeSync,
 	)
@@ -136,7 +134,8 @@ func start(cliCtx *cli.Context) error {
 			b := createBridgeService(
 				cfg.REST,
 				cfg.Common.NetworkID,
-				claimSponsor,
+				claimSponsorFwd,
+				claimSponsorRev,
 				l1InfoTreeSync,
 				lastGERSync,
 				l1BridgeSync,
@@ -726,7 +725,8 @@ func runBridgeSyncL2IfNeeded(
 func createBridgeService(
 	cfg aggkitcommon.RESTConfig,
 	l2NetworkID uint32,
-	sponsor *claimsponsor.ClaimSponsor,
+	sponsorFwd *claimsponsor.ClaimSponsor,
+	sponsorRev *claimsponsor.ClaimSponsor,
 	l1InfoTree *l1infotreesync.L1InfoTreeSync,
 	injectedGERs *lastgersync.LastGERSync,
 	bridgeL1 *bridgesync.BridgeSync,
@@ -746,7 +746,8 @@ func createBridgeService(
 
 	return bridgeservice.New(
 		bridgeCfg,
-		sponsor,
+		sponsorFwd,
+		sponsorRev,
 		l1InfoTree,
 		injectedGERs,
 		bridgeL1,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -93,11 +93,15 @@ func start(cliCtx *cli.Context) error {
 	}
 
 	l1InfoTreeSync := runL1InfoTreeSyncerIfNeeded(cliCtx.Context, components, *cfg, l1Client, reorgDetectorL1)
-	claimSponsor := runClaimSponsorIfNeeded(cliCtx.Context, components, l2Client, cfg.ClaimSponsor)
+	claimSponsor := runClaimSponsorIfNeeded(cliCtx.Context, components, l2Client, cfg.ClaimSponsor, l1InfoTreeSync)
+	autosponsor := claimSponsor
+	if !cfg.ClaimSponsor.ClaimAll {
+		autosponsor = nil
+	}
 	l1BridgeSync := runBridgeSyncL1IfNeeded(cliCtx.Context, components, cfg.BridgeL1Sync, reorgDetectorL1,
-		l1Client, 0)
+		l1Client, 0, autosponsor)
 	l2BridgeSync := runBridgeSyncL2IfNeeded(cliCtx.Context, components, cfg.BridgeL2Sync, reorgDetectorL2,
-		l2Client, rollupDataQuerier.RollupID)
+		l2Client, rollupDataQuerier.RollupID, autosponsor)
 	lastGERSync := runLastGERSyncIfNeeded(
 		cliCtx.Context, components, cfg.LastGERSync, reorgDetectorL2, l2Client, l1InfoTreeSync,
 	)
@@ -553,6 +557,7 @@ func runClaimSponsorIfNeeded(
 	components []string,
 	l2Client aggkittypes.BaseEthereumClienter,
 	cfg claimsponsor.EVMClaimSponsorConfig,
+	l1InfoTree *l1infotreesync.L1InfoTreeSync,
 ) *claimsponsor.ClaimSponsor {
 	if !isNeeded([]string{aggkitcommon.BRIDGE}, components) || !cfg.Enabled {
 		log.Info("ClaimSponsor is not enabled")
@@ -580,6 +585,7 @@ func runClaimSponsorIfNeeded(
 		cfg.MaxRetryAttemptsAfterError,
 		cfg.WaitTxToBeMinedPeriod.Duration,
 		cfg.WaitTxToBeMinedPeriod.Duration,
+		l1InfoTree,
 	)
 	if err != nil {
 		logger.Fatalf("error creating claim sponsor: %s", err)
@@ -636,6 +642,7 @@ func runBridgeSyncL1IfNeeded(
 	reorgDetectorL1 *reorgdetector.ReorgDetector,
 	l1Client aggkittypes.EthClienter,
 	rollupID uint32,
+	autosponsor *claimsponsor.ClaimSponsor,
 ) *bridgesync.BridgeSync {
 	if !isNeeded([]string{aggkitcommon.BRIDGE}, components) {
 		return nil
@@ -656,6 +663,7 @@ func runBridgeSyncL1IfNeeded(
 		rollupID,
 		true,
 		cfg.RequireStorageContentCompatibility,
+		autosponsor,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL1: %s", err)
@@ -672,6 +680,7 @@ func runBridgeSyncL2IfNeeded(
 	reorgDetectorL2 *reorgdetector.ReorgDetector,
 	l2Client aggkittypes.EthClienter,
 	rollupID uint32,
+	autosponsor *claimsponsor.ClaimSponsor,
 ) *bridgesync.BridgeSync {
 	if !isNeeded([]string{
 		aggkitcommon.BRIDGE,
@@ -695,6 +704,7 @@ func runBridgeSyncL2IfNeeded(
 		rollupID,
 		true,
 		cfg.RequireStorageContentCompatibility,
+		autosponsor,
 	)
 	if err != nil {
 		log.Fatalf("error creating bridgeSyncL2: %s", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -97,14 +97,14 @@ func start(cliCtx *cli.Context) error {
 	claimSponsorRev := runClaimSponsorIfNeeded(cliCtx.Context, components, l1Client, cfg.ClaimSponsorReverse, l1InfoTreeSync)
 	var autosponsorL1, autosponsorL2 bridgesync.ClaimEnqueuer
 	if cfg.ClaimSponsor.ClaimAll {
-		autosponsorL1 = claimSponsorRev
-		autosponsorL2 = claimSponsorFwd
+		autosponsorL1 = claimSponsorFwd
+		autosponsorL2 = claimSponsorRev
 	}
 
 	l1BridgeSync := runBridgeSyncL1IfNeeded(cliCtx.Context, components, cfg.BridgeL1Sync, reorgDetectorL1,
-		l1Client, 0, autosponsorL1, 0)
+		l1Client, 0, autosponsorL1, cfg.Common.NetworkID)
 	l2BridgeSync := runBridgeSyncL2IfNeeded(cliCtx.Context, components, cfg.BridgeL2Sync, reorgDetectorL2,
-		l2Client, rollupDataQuerier.RollupID, autosponsorL2, cfg.Common.NetworkID)
+		l2Client, rollupDataQuerier.RollupID, autosponsorL2, 0)
 	lastGERSync := runLastGERSyncIfNeeded(
 		cliCtx.Context, components, cfg.LastGERSync, reorgDetectorL2, l2Client, l1InfoTreeSync,
 	)

--- a/common/global_index.go
+++ b/common/global_index.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"math/big"
+)
+
+const (
+	globalIndexPartSize = 4
+	globalIndexMaxSize  = 9
+)
+
+func GenerateGlobalIndex(mainnetFlag bool, rollupIndex uint32, localExitRootIndex uint32) *big.Int {
+	var (
+		globalIndexBytes []byte
+		buf              [globalIndexPartSize]byte
+	)
+	if mainnetFlag {
+		globalIndexBytes = append(globalIndexBytes, big.NewInt(1).Bytes()...)
+		ri := new(big.Int).FillBytes(buf[:])
+		globalIndexBytes = append(globalIndexBytes, ri...)
+	} else {
+		ri := new(big.Int).SetUint64(uint64(rollupIndex)).FillBytes(buf[:])
+		globalIndexBytes = append(globalIndexBytes, ri...)
+	}
+	leri := new(big.Int).SetUint64(uint64(localExitRootIndex)).FillBytes(buf[:])
+	globalIndexBytes = append(globalIndexBytes, leri...)
+
+	result := new(big.Int).SetBytes(globalIndexBytes)
+
+	return result
+}
+
+// Decodes global index to its three parts:
+// 1. mainnetFlag - first byte
+// 2. rollupIndex - next 4 bytes
+// 3. localExitRootIndex - last 4 bytes
+// NOTE - mainnet flag is not in the global index bytes if it is false
+// NOTE - rollup index is 0 if mainnet flag is true
+// NOTE - rollup index is not in the global index bytes if mainnet flag is false and rollup index is 0
+func DecodeGlobalIndex(globalIndex *big.Int) (mainnetFlag bool,
+	rollupIndex uint32, localExitRootIndex uint32, err error) {
+	globalIndexBytes := globalIndex.Bytes()
+	l := len(globalIndexBytes)
+
+	if l == 0 {
+		// false, 0, 0
+		return
+	}
+
+	if l == globalIndexMaxSize {
+		// true, rollupIndex, localExitRootIndex
+		mainnetFlag = true
+	}
+
+	localExitRootFromIdx := max(l-globalIndexPartSize, 0)
+	rollupIndexFromIdx := max(localExitRootFromIdx-globalIndexPartSize, 0)
+
+	rollupIndex = BytesToUint32(globalIndexBytes[rollupIndexFromIdx:localExitRootFromIdx])
+	localExitRootIndex = BytesToUint32(globalIndexBytes[localExitRootFromIdx:])
+
+	return
+}

--- a/common/utils.go
+++ b/common/utils.go
@@ -60,3 +60,48 @@ func DecodeGlobalIndex(globalIndex *big.Int) (mainnetFlag bool,
 
 	return
 }
+
+// Network ID to Chain ID mappings
+const (
+	NETWORK_ID_MAINNET    = 0
+	NETWORK_ID_AGGLAYER_1 = 1
+	NETWORK_ID_AGGLAYER_2 = 2
+
+	CHAIN_ID_MAINNET    = 1
+	CHAIN_ID_AGGLAYER_1 = 1101
+	CHAIN_ID_AGGLAYER_2 = 137
+)
+
+// chainIDToNetworkID converts chain ID back to network ID for API responses
+// This ensures consistent network ID usage in API responses regardless of what's stored in database
+func ChainIDToNetworkID(chainID uint32) uint32 {
+	switch chainID {
+	case CHAIN_ID_MAINNET:
+		return NETWORK_ID_MAINNET // Ethereum mainnet
+	case CHAIN_ID_AGGLAYER_1:
+		return NETWORK_ID_AGGLAYER_1 // Polygon zkEVM L2
+	case CHAIN_ID_AGGLAYER_2:
+		return NETWORK_ID_AGGLAYER_2 // Polygon
+	case 8453:
+		return 3 // Base
+	default:
+		// For unknown chain IDs or if it's already a network ID, return as-is
+		// This handles cases where the database already contains network IDs
+		return chainID
+	}
+}
+
+// NetworkIDToChainID converts network ID to chain ID as required by the smart contract
+func NetworkIDToChainID(networkID uint32) uint32 {
+	switch networkID {
+	case NETWORK_ID_MAINNET:
+		return CHAIN_ID_MAINNET
+	case NETWORK_ID_AGGLAYER_1:
+		return CHAIN_ID_AGGLAYER_1
+	case NETWORK_ID_AGGLAYER_2:
+		return CHAIN_ID_AGGLAYER_2
+	default:
+		// Default to networkId value
+		return networkID
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -212,8 +212,11 @@ type Config struct {
 	// Configuration of the L1 Info Treee Sync service
 	L1InfoTreeSync l1infotreesync.Config
 
-	// ClaimSponsor is the config for the claim sponsor
+	// ClaimSponsor is the config for the claim sponsor L1 -> L2
 	ClaimSponsor claimsponsor.EVMClaimSponsorConfig
+
+	// ClaimSponsorReverse is the config for the claim sponsor L2 -> L1
+	ClaimSponsorReverse claimsponsor.EVMClaimSponsorConfig
 
 	// BridgeL1Sync is the configuration for the synchronizer of the bridge of the L1
 	BridgeL1Sync bridgesync.Config

--- a/docker/entrypoint-sandbox.sh
+++ b/docker/entrypoint-sandbox.sh
@@ -13,6 +13,7 @@ AGGKIT_SANDBOX_ENABLED=${AGGKIT_SANDBOX_ENABLED:-"true"}
 AGGKIT_LOG_LEVEL=${AGGKIT_LOG_LEVEL:-info}
 AGGKIT_COMPONENTS=${AGGKIT_COMPONENTS:-"bridge,aggoracle,claim-sponsor"}
 AGGKIT_CLAIMSPONSOR_ENABLED=${AGGKIT_CLAIMSPONSOR_ENABLED:-"true"}
+AGGKIT_CLAIMSPONSOR_CLAIM_ALL=${AGGKIT_CLAIMSPONSOR_CLAIM_ALL:-"false"}
 
 # Network configuration
 AGGKIT_L1_CHAIN_ID=${AGGKIT_L1_CHAIN_ID:-${CHAIN_ID_MAINNET:-"1"}}
@@ -137,6 +138,7 @@ MaxRetryAttemptsAfterError = -1
 WaitTxToBeMinedPeriod = "3s"
 WaitOnEmptyQueue = "3s"
 GasOffset = 0
+ClaimAll = $AGGKIT_CLAIMSPONSOR_CLAIM_ALL
 
 [ClaimSponsor.EthTxManager]
 FrequencyToMonitorTxs = "1s"

--- a/docker/entrypoint-sandbox.sh
+++ b/docker/entrypoint-sandbox.sh
@@ -166,6 +166,43 @@ MultiGasProvider = false
 L1ChainID = $AGGKIT_L2_CHAIN_ID
 HTTPHeaders = []
 
+[ClaimSponsorReverse]
+DBPath = "/app/data/claimsponsor_reverse.sqlite"
+Enabled = $AGGKIT_CLAIMSPONSOR_ENABLED
+SenderAddr = "$AGGKIT_EVM_SENDER"
+BridgeAddrL2 = "$POLYGON_ZKEVM_BRIDGE_L1"        # we are on L2, so L1 is "remote"
+MaxGas = 3000000
+RetryAfterErrorPeriod = "1s"
+MaxRetryAttemptsAfterError = -1
+WaitTxToBeMinedPeriod = "3s"
+WaitOnEmptyQueue = "3s"
+GasOffset = 0
+ClaimAll = $AGGKIT_CLAIMSPONSOR_CLAIM_ALL
+
+[ClaimSponsorReverse.EthTxManager]
+FrequencyToMonitorTxs = "1s"
+WaitTxToBeMined = "2s"
+GetReceiptMaxTime = "250ms"
+GetReceiptWaitInterval = "1s"
+ForcedGas = 0
+GasPriceMarginFactor = 1
+MaxGasPriceLimit = 0
+StoragePath = "/app/data/ethtxmanager-claimsponsor_reverse.sqlite"
+ReadPendingL1Txs = false
+SafeStatusL1NumberOfBlocks = 5
+FinalizedStatusL1NumberOfBlocks = 10
+
+[ClaimSponsorReverse.EthTxManager.PrivateKeys]
+Method = "local"
+Path = "/tmp/aggoracle.key"
+Password = "testonly"
+
+[ClaimSponsorReverse.EthTxManager.Etherman]
+URL = "$AGGKIT_L1_URL"            # sending to L1!
+MultiGasProvider = false
+L1ChainID = $AGGKIT_L1_CHAIN_ID
+HTTPHeaders = []
+
 [Database]
 Driver = "$AGGKIT_DATABASE_DRIVER"
 Name = "$AGGKIT_DATABASE_NAME"

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -159,7 +159,7 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 		ctx, dbPathBridgeSyncL1, bridgeL1Addr,
 		syncBlockChunkSize, aggkittypes.LatestBlock, rdL1, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true)
+		retriesCount, originNetwork, false, true, nil)
 	require.NoError(t, err)
 
 	go bridgeL1Sync.Start(ctx)
@@ -224,7 +224,7 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig) *L2Environment {
 		ctx, dbPathL2BridgeSync, bridgeL2Addr, syncBlockChunkSize,
 		aggkittypes.LatestBlock, rdL2, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true)
+		retriesCount, originNetwork, false, true, nil)
 	require.NoError(t, err)
 
 	go bridgeL2Sync.Start(ctx)

--- a/test/helpers/e2e.go
+++ b/test/helpers/e2e.go
@@ -159,7 +159,7 @@ func L1Setup(t *testing.T, cfg *EnvironmentConfig) *L1Environment {
 		ctx, dbPathBridgeSyncL1, bridgeL1Addr,
 		syncBlockChunkSize, aggkittypes.LatestBlock, rdL1, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true, nil)
+		retriesCount, originNetwork, false, true, nil, 0)
 	require.NoError(t, err)
 
 	go bridgeL1Sync.Start(ctx)
@@ -224,7 +224,7 @@ func L2Setup(t *testing.T, cfg *EnvironmentConfig) *L2Environment {
 		ctx, dbPathL2BridgeSync, bridgeL2Addr, syncBlockChunkSize,
 		aggkittypes.LatestBlock, rdL2, testClient,
 		initialBlock, waitForNewBlocksPeriod, retryPeriod,
-		retriesCount, originNetwork, false, true, nil)
+		retriesCount, originNetwork, false, true, nil, 0)
 	require.NoError(t, err)
 
 	go bridgeL2Sync.Start(ctx)

--- a/tools/aggsender_find_imported_bridge/aggsender_find_imported_bridge.go
+++ b/tools/aggsender_find_imported_bridge/aggsender_find_imported_bridge.go
@@ -9,7 +9,7 @@ import (
 	agglayertypes "github.com/agglayer/aggkit/agglayer/types"
 	"github.com/agglayer/aggkit/aggsender/rpcclient"
 	"github.com/agglayer/aggkit/aggsender/types"
-	"github.com/agglayer/aggkit/bridgesync"
+	"github.com/agglayer/aggkit/common"
 	"github.com/agglayer/aggkit/log"
 )
 
@@ -34,7 +34,7 @@ func unmarshalGlobalIndex(globalIndex string) (*agglayertypes.GlobalIndex, error
 		if !ok {
 			return nil, fmt.Errorf("invalid global index: %v", globalIndex)
 		}
-		mainnetFlag, rollupIndex, leafIndex, err := bridgesync.DecodeGlobalIndex(bigInt)
+		mainnetFlag, rollupIndex, leafIndex, err := common.DecodeGlobalIndex(bigInt)
 		if err != nil {
 			return nil, fmt.Errorf("invalid global index, fail to decode: %v", globalIndex)
 		}


### PR DESCRIPTION
This PR enables hands-free claim sponsoring: every new bridge deposit that lands on the destination network is now detected, converted to a Claim, and pushed into the ClaimSponsor queue.
No more manual POST /bridge/v1/sponsor-claim calls needed.

Changes:
- **configuration**: Added a `ClaimAll` flag to indicate whether the claim sponsoring process should be done automatically
- **bridgesync/processor**: After inserting each Bridge Event:
    - Generates the claim body from the BridgeEvent data.
    - Pushes it to autoSponsor.AddClaimToQueue(...) (only if an AutoSponsor has been wired).
    - At this point it is not possible to know the `MainnetExitRoot` and the `RollupExitRoot`, so these would have to be filled by the claimsponsor logic later.
- **claimsponsor**:
    - Before sending the claim, it has to check whether the claim is correct - calls CheckClaim method
    - `CheckClaim` adds the logic for getting the `MainnetExitRoot` and the `RollupExitRoot`, and includes them to the claim body.
- **Global index** helpers moved to common and imported project-wide.
